### PR TITLE
Gltf sig version revisions

### DIFF
--- a/Submissions/GLTF Signature Update/README.md
+++ b/Submissions/GLTF Signature Update/README.md
@@ -1,0 +1,5 @@
+# GL Transmission Format (1 and 2) Signature Update
+
+This signature update allows GLTF files with minor or revision version numbers (e.g. 1.1, 1.0.1, 2.0.1) to be correctly identified, and reduces the chances of spurious matches of "1.0" or "2.0" later in the files.
+
+Sample files include 1.0, 1.0.1 and 2.0.1, and examples deliberately crafted to mis-identify under the previous signature. (These latter files are not valid but will still identify.)

--- a/Submissions/GLTF Signature Update/Samples/fmt-1314_1.0.1_barramundi-misleading-2.0.gltf
+++ b/Submissions/GLTF Signature Update/Samples/fmt-1314_1.0.1_barramundi-misleading-2.0.gltf
@@ -1,0 +1,767 @@
+{
+    "accessors": {
+        "accessor_122": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 44268,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 750,
+            "max": [
+                374
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_124": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 407200,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 750,
+            "max": [
+                7.27421,
+                28.6285,
+                31.6528
+            ],
+            "min": [
+                -6.92326,
+                -0.166827,
+                -32.2417
+            ],
+            "type": "VEC3"
+        },
+        "accessor_126": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 416200,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 750,
+            "max": [
+                0.998718,
+                0.967696,
+                0.888498
+            ],
+            "min": [
+                -0.999555,
+                -0.996096,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_128": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 425200,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 750,
+            "max": [
+                0.974328,
+                0.990452
+            ],
+            "min": [
+                0.0376798,
+                0.0130032
+            ],
+            "type": "VEC2"
+        },
+        "accessor_26": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 0,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 11592,
+            "max": [
+                1100
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_28": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 0,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 2195,
+            "max": [
+                7.38416,
+                28.6628,
+                31.7738
+            ],
+            "min": [
+                -6.9062,
+                -0.0878453,
+                -32.5373
+            ],
+            "type": "VEC3"
+        },
+        "accessor_30": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 26340,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 2195,
+            "max": [
+                0.99977,
+                0.999578,
+                0.998725
+            ],
+            "min": [
+                -0.99977,
+                -0.998968,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_32": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 52680,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 2195,
+            "max": [
+                0.974328,
+                0.992523
+            ],
+            "min": [
+                0.031941,
+                0.0107443
+            ],
+            "type": "VEC2"
+        },
+        "accessor_58": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 23184,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 7530,
+            "max": [
+                3759
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_60": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 70240,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 7519,
+            "max": [
+                7.38416,
+                28.6628,
+                31.7738
+            ],
+            "min": [
+                -6.9062,
+                -0.0878453,
+                -32.5373
+            ],
+            "type": "VEC3"
+        },
+        "accessor_62": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 160468,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 7519,
+            "max": [
+                0.999749,
+                0.999578,
+                0.998725
+            ],
+            "min": [
+                -0.999748,
+                -0.998968,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_64": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 250696,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 7519,
+            "max": [
+                0.974328,
+                0.991917
+            ],
+            "min": [
+                0.031941,
+                0.0107443
+            ],
+            "type": "VEC2"
+        },
+        "accessor_90": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 38244,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 3012,
+            "max": [
+                1504
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_92": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 310848,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 3011,
+            "max": [
+                7.41276,
+                28.6126,
+                31.8281
+            ],
+            "min": [
+                -6.84472,
+                -0.159691,
+                -32.5373
+            ],
+            "type": "VEC3"
+        },
+        "accessor_94": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 346980,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 3011,
+            "max": [
+                0.999999,
+                0.998004,
+                0.993198
+            ],
+            "min": [
+                -0.999999,
+                -0.998933,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_96": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 383112,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 3011,
+            "max": [
+                0.974328,
+                0.990452
+            ],
+            "min": [
+                0.031941,
+                0.0130032
+            ],
+            "type": "VEC2"
+        }
+    },
+    "animations": {},
+    "asset": {
+        "generator": "collada2gltf@f8f6279915175e9d2cc525531660ac439c114fac",
+        "premultipliedAlpha": true,
+        "profile": {
+            "api": "WebGL",
+            "version": "1.0.2"
+        },
+        "version": "1.0.1"
+    },
+    "bufferViews": {
+        "bufferView_130": {
+            "buffer": "BarramundiFish",
+            "byteLength": 45768,
+            "byteOffset": 0,
+            "target": 34963
+        },
+        "bufferView_131": {
+            "buffer": "BarramundiFish",
+            "byteLength": 431200,
+            "byteOffset": 45768,
+            "target": 34962
+        }
+    },
+    "buffers": {
+        "BarramundiFish": {
+            "byteLength": 476968,
+            "type": "arraybuffer",
+            "uri": "BarramundiFish.bin"
+        }
+    },
+    "images": {
+        "m0mtl_barramundi_fish-ambient-image": {
+            "name": "m0mtl_barramundi_fish-ambient-image",
+            "uri": "BarramundiFish_texture_0002.jpg"
+        },
+        "m0mtl_barramundi_fish-diffuse-image": {
+            "name": "m0mtl_barramundi_fish-diffuse-image",
+            "uri": "BarramundiFish_texture_0001.jpg"
+        },
+        "m0mtl_barramundi_fish-normal-image": {
+            "name": "m0mtl_barramundi_fish-normal-image",
+            "uri": "BarramundiFish_texture_0004.jpg"
+        },
+        "m0mtl_barramundi_fish-specular-image": {
+            "name": "m0mtl_barramundi_fish-specular-image",
+            "uri": "BarramundiFish_texture_0003.jpg"
+        }
+    },
+    "materials": {
+        "m0mtl_barramundi_fish-fx": {
+            "name": "m0mtl_barramundi_fish",
+            "technique": "technique0",
+            "values": {
+                "ambient": "texture_m0mtl_barramundi_fish-ambient-image",
+                "diffuse": "texture_m0mtl_barramundi_fish-diffuse-image",
+                "emission": [
+                    0,
+                    0,
+                    0,
+                    1
+                ],
+                "shininess": 20,
+                "specular": "texture_m0mtl_barramundi_fish-specular-image"
+            }
+        }
+    },
+    "meshes": {
+        "meshId0": {
+            "name": "meshId0_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_30",
+                        "POSITION": "accessor_28",
+                        "TEXCOORD_0": "accessor_32"
+                    },
+                    "indices": "accessor_26",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        },
+        "meshId1": {
+            "name": "meshId1_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_62",
+                        "POSITION": "accessor_60",
+                        "TEXCOORD_0": "accessor_64"
+                    },
+                    "indices": "accessor_58",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        },
+        "meshId2": {
+            "name": "meshId2_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_94",
+                        "POSITION": "accessor_92",
+                        "TEXCOORD_0": "accessor_96"
+                    },
+                    "indices": "accessor_90",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        },
+        "meshId3": {
+            "name": "meshId3_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_126",
+                        "POSITION": "accessor_124",
+                        "TEXCOORD_0": "accessor_128"
+                    },
+                    "indices": "accessor_122",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        }
+    },
+    "nodes": {
+        "barramundi_fish_Hero": {
+            "children": [],
+            "meshes": [
+                "meshId0"
+            ],
+            "name": "barramundi_fish_Hero"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_RotationPivot": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_RotationPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_RotationPivot"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_RotationPivotInverse": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_ScalingPivot"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_RotationPivotInverse"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_ScalingPivot": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_ScalingPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_ScalingPivot"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_ScalingPivotInverse": {
+            "children": [
+                "barramundi_fish_Hero"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_ScalingPivotInverse"
+        },
+        "barramundi_fish_LOD01": {
+            "children": [],
+            "meshes": [
+                "meshId1"
+            ],
+            "name": "barramundi_fish_LOD01"
+        },
+        "barramundi_fish_LOD02": {
+            "children": [],
+            "meshes": [
+                "meshId2"
+            ],
+            "name": "barramundi_fish_LOD02"
+        },
+        "barramundi_fish_LOD03": {
+            "children": [],
+            "meshes": [
+                "meshId3"
+            ],
+            "name": "barramundi_fish_LOD03"
+        },
+        "barramundi_fish_LODs": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_RotationPivot",
+                "barramundi_fish_LOD01",
+                "barramundi_fish_LOD02",
+                "barramundi_fish_LOD03"
+            ],
+            "name": "barramundi_fish_LODs"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_RotationPivot": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_RotationPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_RotationPivot"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_RotationPivotInverse": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_ScalingPivot"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_RotationPivotInverse"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_ScalingPivot": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_ScalingPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_ScalingPivot"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_ScalingPivotInverse": {
+            "children": [
+                "barramundi_fish_LODs"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_ScalingPivotInverse"
+        },
+        "barramundi_fish_grp": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_RotationPivot"
+            ],
+            "name": "barramundi_fish_grp"
+        }
+    },
+    "programs": {
+        "program_0": {
+            "attributes": [
+                "a_normal",
+                "a_position",
+                "a_texcoord0"
+            ],
+            "fragmentShader": "BarramundiFish0FS",
+            "vertexShader": "BarramundiFish0VS"
+        }
+    },
+    "samplers": {
+        "sampler_0": {
+            "magFilter": 9729,
+            "minFilter": 9729,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    },
+    "scene": "defaultScene",
+    "scenes": {
+        "defaultScene": {
+            "nodes": [
+                "barramundi_fish_grp"
+            ]
+        }
+    },
+    "shaders": {
+        "BarramundiFish0FS": {
+            "type": 35632,
+            "uri": "BarramundiFish0FS.glsl"
+        },
+        "BarramundiFish0VS": {
+            "type": 35633,
+            "uri": "BarramundiFish0VS.glsl"
+        }
+    },
+    "skins": {},
+    "techniques": {
+        "technique0": {
+            "attributes": {
+                "a_normal": "normal",
+                "a_position": "position",
+                "a_texcoord0": "texcoord0"
+            },
+            "parameters": {
+                "ambient": {
+                    "type": 35678
+                },
+                "diffuse": {
+                    "type": 35678
+                },
+                "emission": {
+                    "type": 35666
+                },
+                "modelViewMatrix": {
+                    "semantic": "MODELVIEW",
+                    "type": 35676
+                },
+                "normal": {
+                    "semantic": "NORMAL",
+                    "type": 35665
+                },
+                "normalMatrix": {
+                    "semantic": "MODELVIEWINVERSETRANSPOSE",
+                    "type": 35675
+                },
+                "position": {
+                    "semantic": "POSITION",
+                    "type": 35665
+                },
+                "projectionMatrix": {
+                    "semantic": "PROJECTION",
+                    "type": 35676
+                },
+                "shininess": {
+                    "type": 5126
+                },
+                "specular": {
+                    "type": 35678
+                },
+                "texcoord0": {
+                    "semantic": "TEXCOORD_0",
+                    "type": 35664
+                }
+            },
+            "program": "program_0",
+            "states": {
+                "enable": [
+                    2929,
+                    2884
+                ]
+            },
+            "uniforms": {
+                "u_ambient": "ambient",
+                "u_diffuse": "diffuse",
+                "u_emission": "emission",
+                "u_modelViewMatrix": "modelViewMatrix",
+                "u_normalMatrix": "normalMatrix",
+                "u_projectionMatrix": "projectionMatrix",
+                "u_shininess": "shininess",
+                "u_specular": "specular"
+            }
+        }
+    },
+    "textures": {
+        "texture_m0mtl_barramundi_fish-ambient-image": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "m0mtl_barramundi_fish-ambient-image",
+            "target": 3553,
+            "type": 5121
+        },
+        "texture_m0mtl_barramundi_fish-diffuse-image": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "m0mtl_barramundi_fish-diffuse-image",
+            "target": 3553,
+            "type": 5121
+        },
+        "texture_m0mtl_barramundi_fish-specular-image": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "m0mtl_barramundi_fish-specular-image",
+            "target": 3553,
+            "type": 5121
+        }
+    }, "dummy": {
+	"property": "2.0"
+  }
+}

--- a/Submissions/GLTF Signature Update/Samples/fmt-1314_1.0.1_barramundi.gltf
+++ b/Submissions/GLTF Signature Update/Samples/fmt-1314_1.0.1_barramundi.gltf
@@ -1,0 +1,765 @@
+{
+    "accessors": {
+        "accessor_122": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 44268,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 750,
+            "max": [
+                374
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_124": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 407200,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 750,
+            "max": [
+                7.27421,
+                28.6285,
+                31.6528
+            ],
+            "min": [
+                -6.92326,
+                -0.166827,
+                -32.2417
+            ],
+            "type": "VEC3"
+        },
+        "accessor_126": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 416200,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 750,
+            "max": [
+                0.998718,
+                0.967696,
+                0.888498
+            ],
+            "min": [
+                -0.999555,
+                -0.996096,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_128": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 425200,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 750,
+            "max": [
+                0.974328,
+                0.990452
+            ],
+            "min": [
+                0.0376798,
+                0.0130032
+            ],
+            "type": "VEC2"
+        },
+        "accessor_26": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 0,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 11592,
+            "max": [
+                1100
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_28": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 0,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 2195,
+            "max": [
+                7.38416,
+                28.6628,
+                31.7738
+            ],
+            "min": [
+                -6.9062,
+                -0.0878453,
+                -32.5373
+            ],
+            "type": "VEC3"
+        },
+        "accessor_30": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 26340,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 2195,
+            "max": [
+                0.99977,
+                0.999578,
+                0.998725
+            ],
+            "min": [
+                -0.99977,
+                -0.998968,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_32": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 52680,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 2195,
+            "max": [
+                0.974328,
+                0.992523
+            ],
+            "min": [
+                0.031941,
+                0.0107443
+            ],
+            "type": "VEC2"
+        },
+        "accessor_58": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 23184,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 7530,
+            "max": [
+                3759
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_60": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 70240,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 7519,
+            "max": [
+                7.38416,
+                28.6628,
+                31.7738
+            ],
+            "min": [
+                -6.9062,
+                -0.0878453,
+                -32.5373
+            ],
+            "type": "VEC3"
+        },
+        "accessor_62": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 160468,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 7519,
+            "max": [
+                0.999749,
+                0.999578,
+                0.998725
+            ],
+            "min": [
+                -0.999748,
+                -0.998968,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_64": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 250696,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 7519,
+            "max": [
+                0.974328,
+                0.991917
+            ],
+            "min": [
+                0.031941,
+                0.0107443
+            ],
+            "type": "VEC2"
+        },
+        "accessor_90": {
+            "bufferView": "bufferView_130",
+            "byteOffset": 38244,
+            "byteStride": 2,
+            "componentType": 5123,
+            "count": 3012,
+            "max": [
+                1504
+            ],
+            "min": [
+                0
+            ],
+            "type": "SCALAR"
+        },
+        "accessor_92": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 310848,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 3011,
+            "max": [
+                7.41276,
+                28.6126,
+                31.8281
+            ],
+            "min": [
+                -6.84472,
+                -0.159691,
+                -32.5373
+            ],
+            "type": "VEC3"
+        },
+        "accessor_94": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 346980,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 3011,
+            "max": [
+                0.999999,
+                0.998004,
+                0.993198
+            ],
+            "min": [
+                -0.999999,
+                -0.998933,
+                -0.999925
+            ],
+            "type": "VEC3"
+        },
+        "accessor_96": {
+            "bufferView": "bufferView_131",
+            "byteOffset": 383112,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 3011,
+            "max": [
+                0.974328,
+                0.990452
+            ],
+            "min": [
+                0.031941,
+                0.0130032
+            ],
+            "type": "VEC2"
+        }
+    },
+    "animations": {},
+    "asset": {
+        "generator": "collada2gltf@f8f6279915175e9d2cc525531660ac439c114fac",
+        "premultipliedAlpha": true,
+        "profile": {
+            "api": "WebGL",
+            "version": "1.0.2"
+        },
+        "version": "1.0.1"
+    },
+    "bufferViews": {
+        "bufferView_130": {
+            "buffer": "BarramundiFish",
+            "byteLength": 45768,
+            "byteOffset": 0,
+            "target": 34963
+        },
+        "bufferView_131": {
+            "buffer": "BarramundiFish",
+            "byteLength": 431200,
+            "byteOffset": 45768,
+            "target": 34962
+        }
+    },
+    "buffers": {
+        "BarramundiFish": {
+            "byteLength": 476968,
+            "type": "arraybuffer",
+            "uri": "BarramundiFish.bin"
+        }
+    },
+    "images": {
+        "m0mtl_barramundi_fish-ambient-image": {
+            "name": "m0mtl_barramundi_fish-ambient-image",
+            "uri": "BarramundiFish_texture_0002.jpg"
+        },
+        "m0mtl_barramundi_fish-diffuse-image": {
+            "name": "m0mtl_barramundi_fish-diffuse-image",
+            "uri": "BarramundiFish_texture_0001.jpg"
+        },
+        "m0mtl_barramundi_fish-normal-image": {
+            "name": "m0mtl_barramundi_fish-normal-image",
+            "uri": "BarramundiFish_texture_0004.jpg"
+        },
+        "m0mtl_barramundi_fish-specular-image": {
+            "name": "m0mtl_barramundi_fish-specular-image",
+            "uri": "BarramundiFish_texture_0003.jpg"
+        }
+    },
+    "materials": {
+        "m0mtl_barramundi_fish-fx": {
+            "name": "m0mtl_barramundi_fish",
+            "technique": "technique0",
+            "values": {
+                "ambient": "texture_m0mtl_barramundi_fish-ambient-image",
+                "diffuse": "texture_m0mtl_barramundi_fish-diffuse-image",
+                "emission": [
+                    0,
+                    0,
+                    0,
+                    1
+                ],
+                "shininess": 20,
+                "specular": "texture_m0mtl_barramundi_fish-specular-image"
+            }
+        }
+    },
+    "meshes": {
+        "meshId0": {
+            "name": "meshId0_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_30",
+                        "POSITION": "accessor_28",
+                        "TEXCOORD_0": "accessor_32"
+                    },
+                    "indices": "accessor_26",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        },
+        "meshId1": {
+            "name": "meshId1_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_62",
+                        "POSITION": "accessor_60",
+                        "TEXCOORD_0": "accessor_64"
+                    },
+                    "indices": "accessor_58",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        },
+        "meshId2": {
+            "name": "meshId2_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_94",
+                        "POSITION": "accessor_92",
+                        "TEXCOORD_0": "accessor_96"
+                    },
+                    "indices": "accessor_90",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        },
+        "meshId3": {
+            "name": "meshId3_name",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_126",
+                        "POSITION": "accessor_124",
+                        "TEXCOORD_0": "accessor_128"
+                    },
+                    "indices": "accessor_122",
+                    "material": "m0mtl_barramundi_fish-fx",
+                    "mode": 4
+                }
+            ]
+        }
+    },
+    "nodes": {
+        "barramundi_fish_Hero": {
+            "children": [],
+            "meshes": [
+                "meshId0"
+            ],
+            "name": "barramundi_fish_Hero"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_RotationPivot": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_RotationPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_RotationPivot"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_RotationPivotInverse": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_ScalingPivot"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_RotationPivotInverse"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_ScalingPivot": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_ScalingPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_ScalingPivot"
+        },
+        "barramundi_fish_Hero_$AssimpFbx$_ScalingPivotInverse": {
+            "children": [
+                "barramundi_fish_Hero"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_Hero_$AssimpFbx$_ScalingPivotInverse"
+        },
+        "barramundi_fish_LOD01": {
+            "children": [],
+            "meshes": [
+                "meshId1"
+            ],
+            "name": "barramundi_fish_LOD01"
+        },
+        "barramundi_fish_LOD02": {
+            "children": [],
+            "meshes": [
+                "meshId2"
+            ],
+            "name": "barramundi_fish_LOD02"
+        },
+        "barramundi_fish_LOD03": {
+            "children": [],
+            "meshes": [
+                "meshId3"
+            ],
+            "name": "barramundi_fish_LOD03"
+        },
+        "barramundi_fish_LODs": {
+            "children": [
+                "barramundi_fish_Hero_$AssimpFbx$_RotationPivot",
+                "barramundi_fish_LOD01",
+                "barramundi_fish_LOD02",
+                "barramundi_fish_LOD03"
+            ],
+            "name": "barramundi_fish_LODs"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_RotationPivot": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_RotationPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_RotationPivot"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_RotationPivotInverse": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_ScalingPivot"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_RotationPivotInverse"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_ScalingPivot": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_ScalingPivotInverse"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0.238983,
+                14.2875,
+                -0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_ScalingPivot"
+        },
+        "barramundi_fish_LODs_$AssimpFbx$_ScalingPivotInverse": {
+            "children": [
+                "barramundi_fish_LODs"
+            ],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                -0.238983,
+                -14.2875,
+                0.381729,
+                1
+            ],
+            "name": "barramundi_fish_LODs_$AssimpFbx$_ScalingPivotInverse"
+        },
+        "barramundi_fish_grp": {
+            "children": [
+                "barramundi_fish_LODs_$AssimpFbx$_RotationPivot"
+            ],
+            "name": "barramundi_fish_grp"
+        }
+    },
+    "programs": {
+        "program_0": {
+            "attributes": [
+                "a_normal",
+                "a_position",
+                "a_texcoord0"
+            ],
+            "fragmentShader": "BarramundiFish0FS",
+            "vertexShader": "BarramundiFish0VS"
+        }
+    },
+    "samplers": {
+        "sampler_0": {
+            "magFilter": 9729,
+            "minFilter": 9729,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    },
+    "scene": "defaultScene",
+    "scenes": {
+        "defaultScene": {
+            "nodes": [
+                "barramundi_fish_grp"
+            ]
+        }
+    },
+    "shaders": {
+        "BarramundiFish0FS": {
+            "type": 35632,
+            "uri": "BarramundiFish0FS.glsl"
+        },
+        "BarramundiFish0VS": {
+            "type": 35633,
+            "uri": "BarramundiFish0VS.glsl"
+        }
+    },
+    "skins": {},
+    "techniques": {
+        "technique0": {
+            "attributes": {
+                "a_normal": "normal",
+                "a_position": "position",
+                "a_texcoord0": "texcoord0"
+            },
+            "parameters": {
+                "ambient": {
+                    "type": 35678
+                },
+                "diffuse": {
+                    "type": 35678
+                },
+                "emission": {
+                    "type": 35666
+                },
+                "modelViewMatrix": {
+                    "semantic": "MODELVIEW",
+                    "type": 35676
+                },
+                "normal": {
+                    "semantic": "NORMAL",
+                    "type": 35665
+                },
+                "normalMatrix": {
+                    "semantic": "MODELVIEWINVERSETRANSPOSE",
+                    "type": 35675
+                },
+                "position": {
+                    "semantic": "POSITION",
+                    "type": 35665
+                },
+                "projectionMatrix": {
+                    "semantic": "PROJECTION",
+                    "type": 35676
+                },
+                "shininess": {
+                    "type": 5126
+                },
+                "specular": {
+                    "type": 35678
+                },
+                "texcoord0": {
+                    "semantic": "TEXCOORD_0",
+                    "type": 35664
+                }
+            },
+            "program": "program_0",
+            "states": {
+                "enable": [
+                    2929,
+                    2884
+                ]
+            },
+            "uniforms": {
+                "u_ambient": "ambient",
+                "u_diffuse": "diffuse",
+                "u_emission": "emission",
+                "u_modelViewMatrix": "modelViewMatrix",
+                "u_normalMatrix": "normalMatrix",
+                "u_projectionMatrix": "projectionMatrix",
+                "u_shininess": "shininess",
+                "u_specular": "specular"
+            }
+        }
+    },
+    "textures": {
+        "texture_m0mtl_barramundi_fish-ambient-image": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "m0mtl_barramundi_fish-ambient-image",
+            "target": 3553,
+            "type": 5121
+        },
+        "texture_m0mtl_barramundi_fish-diffuse-image": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "m0mtl_barramundi_fish-diffuse-image",
+            "target": 3553,
+            "type": 5121
+        },
+        "texture_m0mtl_barramundi_fish-specular-image": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "m0mtl_barramundi_fish-specular-image",
+            "target": 3553,
+            "type": 5121
+        }
+    }
+}

--- a/Submissions/GLTF Signature Update/Samples/fmt-1314_1.0_duck.gltf
+++ b/Submissions/GLTF Signature Update/Samples/fmt-1314_1.0_duck.gltf
@@ -1,0 +1,362 @@
+{
+    "accessors": {
+        "accessor_21": {
+            "bufferView": "bufferView_29",
+            "byteOffset": 0,
+            "byteStride": 0,
+            "componentType": 5123,
+            "count": 12636,
+            "type": "SCALAR"
+        },
+        "accessor_23": {
+            "bufferView": "bufferView_30",
+            "byteOffset": 0,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 2399,
+            "max": [
+                0.961799,
+                1.6397,
+                0.539252
+            ],
+            "min": [
+                -0.692985,
+                0.0992937,
+                -0.613282
+            ],
+            "type": "VEC3"
+        },
+        "accessor_25": {
+            "bufferView": "bufferView_30",
+            "byteOffset": 28788,
+            "byteStride": 12,
+            "componentType": 5126,
+            "count": 2399,
+            "max": [
+                0.999599,
+                0.999581,
+                0.998436
+            ],
+            "min": [
+                -0.999084,
+                -1,
+                -0.999832
+            ],
+            "type": "VEC3"
+        },
+        "accessor_27": {
+            "bufferView": "bufferView_30",
+            "byteOffset": 57576,
+            "byteStride": 8,
+            "componentType": 5126,
+            "count": 2399,
+            "max": [
+                0.983346,
+                0.980037
+            ],
+            "min": [
+                0.026409,
+                0.019963
+            ],
+            "type": "VEC2"
+        }
+    },
+    "animations": {},
+    "asset": {
+        "generator": "collada2gltf@027f74366341d569dea42e9a68b7104cc3892054",
+        "premultipliedAlpha": true,
+        "profile": {
+            "api": "WebGL",
+            "version": "1.0.2"
+        },
+        "version": "1.0"
+    },
+    "bufferViews": {
+        "bufferView_29": {
+            "buffer": "Duck",
+            "byteLength": 25272,
+            "byteOffset": 0,
+            "target": 34963
+        },
+        "bufferView_30": {
+            "buffer": "Duck",
+            "byteLength": 76768,
+            "byteOffset": 25272,
+            "target": 34962
+        }
+    },
+    "buffers": {
+        "Duck": {
+            "byteLength": 102040,
+            "type": "arraybuffer",
+            "uri": "Duck.bin"
+        }
+    },
+    "cameras": {
+        "cameraShape1": {
+            "name": "cameraShape1",
+            "perspective": {
+                "aspectRatio": 1.5,
+                "yfov": 0.660593,
+                "zfar": 100,
+                "znear": 0.01
+            },
+            "type": "perspective"
+        }
+    },
+    "images": {
+        "file2": {
+            "name": "file2",
+            "uri": "DuckCM.png"
+        }
+    },
+    "materials": {
+        "blinn3-fx": {
+            "name": "blinn3",
+            "technique": "technique0",
+            "values": {
+                "ambient": [
+                    0,
+                    0,
+                    0,
+                    1
+                ],
+                "diffuse": "texture_file2",
+                "emission": [
+                    0,
+                    0,
+                    0,
+                    1
+                ],
+                "shininess": 38.4,
+                "specular": [
+                    0,
+                    0,
+                    0,
+                    1
+                ]
+            }
+        }
+    },
+    "meshes": {
+        "LOD3spShape-lib": {
+            "name": "LOD3spShape",
+            "primitives": [
+                {
+                    "attributes": {
+                        "NORMAL": "accessor_25",
+                        "POSITION": "accessor_23",
+                        "TEXCOORD_0": "accessor_27"
+                    },
+                    "indices": "accessor_21",
+                    "material": "blinn3-fx",
+                    "mode": 4
+                }
+            ]
+        }
+    },
+    "nodes": {
+        "LOD3sp": {
+            "children": [],
+            "matrix": [
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1,
+                0,
+                0,
+                0,
+                0,
+                1
+            ],
+            "meshes": [
+                "LOD3spShape-lib"
+            ],
+            "name": "LOD3sp"
+        },
+        "camera1": {
+            "camera": "cameraShape1",
+            "children": [],
+            "matrix": [
+                -0.728969,
+                0,
+                -0.684547,
+                0,
+                -0.425205,
+                0.783693,
+                0.452797,
+                0,
+                0.536475,
+                0.621148,
+                -0.571288,
+                0,
+                4.00113,
+                4.63264,
+                -4.31078,
+                1
+            ],
+            "name": "camera1"
+        },
+        "directionalLight1": {
+            "children": [],
+            "matrix": [
+                -0.954692,
+                0.218143,
+                -0.202429,
+                0,
+                0.014672,
+                0.713885,
+                0.700109,
+                0,
+                0.297235,
+                0.665418,
+                -0.684741,
+                0,
+                1.48654,
+                1.83672,
+                -2.92179,
+                1
+            ],
+            "name": "directionalLight1"
+        }
+    },
+    "programs": {
+        "program_0": {
+            "attributes": [
+                "a_normal",
+                "a_position",
+                "a_texcoord0"
+            ],
+            "fragmentShader": "Duck0FS",
+            "vertexShader": "Duck0VS"
+        }
+    },
+    "samplers": {
+        "sampler_0": {
+            "magFilter": 9729,
+            "minFilter": 9987,
+            "wrapS": 10497,
+            "wrapT": 10497
+        }
+    },
+    "scene": "defaultScene",
+    "scenes": {
+        "defaultScene": {
+            "nodes": [
+                "LOD3sp",
+                "camera1",
+                "directionalLight1"
+            ]
+        }
+    },
+    "shaders": {
+        "Duck0FS": {
+            "type": 35632,
+            "uri": "Duck0FS.glsl"
+        },
+        "Duck0VS": {
+            "type": 35633,
+            "uri": "Duck0VS.glsl"
+        }
+    },
+    "skins": {},
+    "techniques": {
+        "technique0": {
+            "attributes": {
+                "a_normal": "normal",
+                "a_position": "position",
+                "a_texcoord0": "texcoord0"
+            },
+            "parameters": {
+                "ambient": {
+                    "type": 35666
+                },
+                "diffuse": {
+                    "type": 35678
+                },
+                "emission": {
+                    "type": 35666
+                },
+                "light0Color": {
+                    "type": 35665,
+                    "value": [
+                        1,
+                        1,
+                        1
+                    ]
+                },
+                "light0Transform": {
+                    "node": "directionalLight1",
+                    "semantic": "MODELVIEW",
+                    "type": 35676
+                },
+                "modelViewMatrix": {
+                    "semantic": "MODELVIEW",
+                    "type": 35676
+                },
+                "normal": {
+                    "semantic": "NORMAL",
+                    "type": 35665
+                },
+                "normalMatrix": {
+                    "semantic": "MODELVIEWINVERSETRANSPOSE",
+                    "type": 35675
+                },
+                "position": {
+                    "semantic": "POSITION",
+                    "type": 35665
+                },
+                "projectionMatrix": {
+                    "semantic": "PROJECTION",
+                    "type": 35676
+                },
+                "shininess": {
+                    "type": 5126
+                },
+                "specular": {
+                    "type": 35666
+                },
+                "texcoord0": {
+                    "semantic": "TEXCOORD_0",
+                    "type": 35664
+                }
+            },
+            "program": "program_0",
+            "states": {
+                "enable": [
+                    2929,
+                    2884
+                ]
+            },
+            "uniforms": {
+                "u_ambient": "ambient",
+                "u_diffuse": "diffuse",
+                "u_emission": "emission",
+                "u_light0Color": "light0Color",
+                "u_light0Transform": "light0Transform",
+                "u_modelViewMatrix": "modelViewMatrix",
+                "u_normalMatrix": "normalMatrix",
+                "u_projectionMatrix": "projectionMatrix",
+                "u_shininess": "shininess",
+                "u_specular": "specular"
+            }
+        }
+    },
+    "textures": {
+        "texture_file2": {
+            "format": 6408,
+            "internalFormat": 6408,
+            "sampler": "sampler_0",
+            "source": "file2",
+            "target": 3553,
+            "type": 5121
+        }
+    }
+}

--- a/Submissions/GLTF Signature Update/Samples/fmt-1315_2.0.1_barramundi.gltf
+++ b/Submissions/GLTF Signature Update/Samples/fmt-1315_2.0.1_barramundi.gltf
@@ -1,0 +1,160 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC4"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC3",
+      "max": [
+        0.0690619648,
+        0.2866283,
+        0.3253729
+      ],
+      "min": [
+        -0.073841624,
+        -0.000878453255,
+        -0.317738324
+      ]
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5123,
+      "count": 11592,
+      "type": "SCALAR"
+    }
+  ],
+  "asset": {
+    "generator": "glTF Tools for Unity",
+    "version": "2.0.1"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 17504
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 17504,
+      "byteLength": 26256
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 43760,
+      "byteLength": 35008
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 78768,
+      "byteLength": 26256
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 105024,
+      "byteLength": 23184
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "BarramundiFish.bin",
+      "byteLength": 128208
+    }
+  ],
+  "images": [
+    {
+      "uri": "BarramundiFish_baseColor.png"
+    },
+    {
+      "uri": "BarramundiFish_occlusionRoughnessMetallic.png"
+    },
+    {
+      "uri": "BarramundiFish_normal.png"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "TEXCOORD_0": 0,
+            "NORMAL": 1,
+            "TANGENT": 2,
+            "POSITION": 3
+          },
+          "indices": 4,
+          "material": 0
+        }
+      ],
+      "name": "barramundi_fish_Hero"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 0
+        },
+        "metallicRoughnessTexture": {
+          "index": 1
+        }
+      },
+      "normalTexture": {
+        "index": 2
+      },
+      "occlusionTexture": {
+        "index": 1
+      },
+      "name": "7288_barramundi fish_col"
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0,
+      "rotation": [
+        0.0,
+        1.0,
+        0.0,
+        0.0
+      ],
+      "name": "BarramundiFish"
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "textures": [
+    {
+      "source": 0
+    },
+    {
+      "source": 1
+    },
+    {
+      "source": 2
+    }
+  ], "dummy": {
+	"property": "1.0"
+  }
+}

--- a/Submissions/GLTF Signature Update/Samples/fmt-1315_2.0_barramundi.gltf
+++ b/Submissions/GLTF Signature Update/Samples/fmt-1315_2.0_barramundi.gltf
@@ -1,0 +1,158 @@
+{
+  "accessors": [
+    {
+      "bufferView": 0,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC2"
+    },
+    {
+      "bufferView": 1,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC3"
+    },
+    {
+      "bufferView": 2,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC4"
+    },
+    {
+      "bufferView": 3,
+      "componentType": 5126,
+      "count": 2188,
+      "type": "VEC3",
+      "max": [
+        0.0690619648,
+        0.2866283,
+        0.3253729
+      ],
+      "min": [
+        -0.073841624,
+        -0.000878453255,
+        -0.317738324
+      ]
+    },
+    {
+      "bufferView": 4,
+      "componentType": 5123,
+      "count": 11592,
+      "type": "SCALAR"
+    }
+  ],
+  "asset": {
+    "generator": "glTF Tools for Unity",
+    "version": "2.0"
+  },
+  "bufferViews": [
+    {
+      "buffer": 0,
+      "byteLength": 17504
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 17504,
+      "byteLength": 26256
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 43760,
+      "byteLength": 35008
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 78768,
+      "byteLength": 26256
+    },
+    {
+      "buffer": 0,
+      "byteOffset": 105024,
+      "byteLength": 23184
+    }
+  ],
+  "buffers": [
+    {
+      "uri": "BarramundiFish.bin",
+      "byteLength": 128208
+    }
+  ],
+  "images": [
+    {
+      "uri": "BarramundiFish_baseColor.png"
+    },
+    {
+      "uri": "BarramundiFish_occlusionRoughnessMetallic.png"
+    },
+    {
+      "uri": "BarramundiFish_normal.png"
+    }
+  ],
+  "meshes": [
+    {
+      "primitives": [
+        {
+          "attributes": {
+            "TEXCOORD_0": 0,
+            "NORMAL": 1,
+            "TANGENT": 2,
+            "POSITION": 3
+          },
+          "indices": 4,
+          "material": 0
+        }
+      ],
+      "name": "barramundi_fish_Hero"
+    }
+  ],
+  "materials": [
+    {
+      "pbrMetallicRoughness": {
+        "baseColorTexture": {
+          "index": 0
+        },
+        "metallicRoughnessTexture": {
+          "index": 1
+        }
+      },
+      "normalTexture": {
+        "index": 2
+      },
+      "occlusionTexture": {
+        "index": 1
+      },
+      "name": "7288_barramundi fish_col"
+    }
+  ],
+  "nodes": [
+    {
+      "mesh": 0,
+      "rotation": [
+        0.0,
+        1.0,
+        0.0,
+        0.0
+      ],
+      "name": "BarramundiFish"
+    }
+  ],
+  "scene": 0,
+  "scenes": [
+    {
+      "nodes": [
+        0
+      ]
+    }
+  ],
+  "textures": [
+    {
+      "source": 0
+    },
+    {
+      "source": 1
+    },
+    {
+      "source": 2
+    }
+  ]
+}

--- a/Submissions/GLTF Signature Update/gltf-1-sig-updates.xml
+++ b/Submissions/GLTF Signature Update/gltf-1-sig-updates.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FFSignatureFile xmlns="http://www.nationalarchives.gov.uk/pronom/SignatureFile" Version="1" DateCreated="2019-11-21T16:10:10+00:00">
+	<InternalSignatureCollection>
+		<!-- GLTF 1.0 -->
+		<InternalSignature ID="1">
+			<ByteSequence Reference="BOFoffset" Endianness="">
+				<SubSequence Position="1" SubSeqMinOffset="0" SubSeqMaxOffset="5" MinFragLength="0">
+					<Sequence>7B</Sequence>
+					<DefaultShift>2</DefaultShift>
+					<Shift Byte="7B">1</Shift>
+				</SubSequence>
+				<SubSequence Position="2" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>22617373657422</Sequence>
+					<DefaultShift>8</DefaultShift>
+					<Shift Byte="22">1</Shift>
+					<Shift Byte="61">6</Shift>
+					<Shift Byte="65">3</Shift>
+					<Shift Byte="73">4</Shift>
+					<Shift Byte="74">2</Shift>
+				</SubSequence>
+				<SubSequence Position="3" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>3A</Sequence>
+					<DefaultShift>2</DefaultShift>
+					<Shift Byte="3A">1</Shift>
+				</SubSequence>
+				<SubSequence Position="4" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>7B</Sequence>
+					<DefaultShift>2</DefaultShift>
+					<Shift Byte="7B">1</Shift>
+				</SubSequence>
+				<SubSequence Position="5" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>2276657273696F6E22</Sequence>
+					<DefaultShift>10</DefaultShift>
+					<Shift Byte="22">1</Shift>
+					<Shift Byte="65">7</Shift>
+					<Shift Byte="69">4</Shift>
+					<Shift Byte="6E">2</Shift>
+					<Shift Byte="6F">3</Shift>
+					<Shift Byte="72">6</Shift>
+					<Shift Byte="73">5</Shift>
+					<Shift Byte="76">8</Shift>
+					<RightFragment Position="1" MinOffset="0" MaxOffset="20">3A</RightFragment>
+					<RightFragment Position="2" MinOffset="0" MaxOffset="20">22312E</RightFragment>
+					<RightFragment Position="3" MinOffset="1" MaxOffset="10">22</RightFragment>
+				</SubSequence>
+			</ByteSequence>
+			<ByteSequence Reference="EOFoffset" Endianness="">
+				<SubSequence Position="1" SubSeqMinOffset="0" SubSeqMaxOffset="5" MinFragLength="0">
+					<Sequence>7D</Sequence>
+					<DefaultShift>-2</DefaultShift>
+					<Shift Byte="7D">-1</Shift>
+				</SubSequence>
+			</ByteSequence>
+		</InternalSignature>
+	</InternalSignatureCollection>
+	
+	<FileFormatCollection>
+		<FileFormat ID="1" Name="GL Transmission Format" PUID="fmt/1314" Version="1.0" MIMEType="application/json">
+			<InternalSignatureID>1</InternalSignatureID>
+			<Extension>gltf</Extension>
+		</FileFormat>
+	</FileFormatCollection>
+</FFSignatureFile>

--- a/Submissions/GLTF Signature Update/gltf-2-sig-updates.xml
+++ b/Submissions/GLTF Signature Update/gltf-2-sig-updates.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<FFSignatureFile xmlns="http://www.nationalarchives.gov.uk/pronom/SignatureFile" Version="1" DateCreated="2019-11-21T16:10:10+00:00">
+	<InternalSignatureCollection>
+		<!-- GLTF 2.0 -->
+		<InternalSignature ID="1">
+			<ByteSequence Reference="BOFoffset" Endianness="">
+				<SubSequence Position="1" SubSeqMinOffset="0" SubSeqMaxOffset="5" MinFragLength="0">
+					<Sequence>7B</Sequence>
+					<DefaultShift>2</DefaultShift>
+					<Shift Byte="7B">1</Shift>
+				</SubSequence>
+				<SubSequence Position="2" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>22617373657422</Sequence>
+					<DefaultShift>8</DefaultShift>
+					<Shift Byte="22">1</Shift>
+					<Shift Byte="61">6</Shift>
+					<Shift Byte="65">3</Shift>
+					<Shift Byte="73">4</Shift>
+					<Shift Byte="74">2</Shift>
+				</SubSequence>
+				<SubSequence Position="3" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>3A</Sequence>
+					<DefaultShift>2</DefaultShift>
+					<Shift Byte="3A">1</Shift>
+				</SubSequence>
+				<SubSequence Position="4" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>7B</Sequence>
+					<DefaultShift>2</DefaultShift>
+					<Shift Byte="7B">1</Shift>
+				</SubSequence>
+				<SubSequence Position="5" SubSeqMinOffset="0" MinFragLength="0">
+					<Sequence>2276657273696F6E22</Sequence>
+					<DefaultShift>10</DefaultShift>
+					<Shift Byte="22">1</Shift>
+					<Shift Byte="65">7</Shift>
+					<Shift Byte="69">4</Shift>
+					<Shift Byte="6E">2</Shift>
+					<Shift Byte="6F">3</Shift>
+					<Shift Byte="72">6</Shift>
+					<Shift Byte="73">5</Shift>
+					<Shift Byte="76">8</Shift>
+					<RightFragment Position="1" MinOffset="0" MaxOffset="20">3A</RightFragment>
+					<RightFragment Position="2" MinOffset="0" MaxOffset="20">22322E</RightFragment>
+					<RightFragment Position="3" MinOffset="1" MaxOffset="10">22</RightFragment>
+				</SubSequence>
+			</ByteSequence>
+			<ByteSequence Reference="EOFoffset" Endianness="">
+				<SubSequence Position="1" SubSeqMinOffset="0" SubSeqMaxOffset="5" MinFragLength="0">
+					<Sequence>7D</Sequence>
+					<DefaultShift>-2</DefaultShift>
+					<Shift Byte="7D">-1</Shift>
+				</SubSequence>
+			</ByteSequence>
+		</InternalSignature>
+	</InternalSignatureCollection>
+	
+	<FileFormatCollection>
+		<FileFormat ID="1" Name="GL Transmission Format" PUID="fmt/1315" Version="2.0" MIMEType="application/json">
+			<InternalSignatureID>1</InternalSignatureID>
+			<Extension>gltf</Extension>
+		</FileFormat>
+	</FileFormatCollection>
+</FFSignatureFile>


### PR DESCRIPTION
This signature update allows GLTF files with minor or revision version numbers (e.g. 1.1, 1.0.1, 2.0.1) to be correctly identified, and reduces the chances of spurious matches of "1.0" or "2.0" later in the files.

The current signature for fmt/1314 and 1315 only accept exactly "1.0" and "2.0", but the standard allows minor and revision versions (the 2.0 spec is explicit about this).