### PR TITLE
Fix double percent-encoded URLs in iCalendar files

### DIFF
--- a/Resources/calendar/pronom-drop-in-aet.ics
+++ b/Resources/calendar/pronom-drop-in-aet.ics
@@ -29,8 +29,8 @@ DTSTART;TZID=Europe/Berlin:20230525T080000
 RRULE:FREQ=MONTHLY;BYDAY=-1TH
 DTEND;TZID=Europe/Berlin:20230525T090000
 SUMMARY:PRONOM Drop-in Session (Australasia)
-URL:https://teams.microsoft.com/l/meetup-join/19%253ameeting_MDIzODI0M2YtZWQ5ZS00NjgyLWIwODMtYTljOWUzMTI1Yjlk%2540thread.v2/0?context=%257b%2522Tid%2522%253a%2522f99512c1-fd9f-4475-9896-9a0b3cdc50ec%2522%252c%2522Oid%2522%253a%2522e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%2522%257d
-DESCRIPTION:The PRONOM team would also like to share details of their PRONOM drop-in sessions. These are open/unstructured sessions with members of the PRONOM Team to talk about your current research and ask/answer any questions you may have. \n\nhttps://teams.microsoft.com/l/meetup-join/19%253ameeting_MDIzODI0M2YtZWQ5ZS00NjgyLWIwODMtYTljOWUzMTI1Yjlk%2540thread.v2/0?context=%257b%2522Tid%2522%253a%2522f99512c1-fd9f-4475-9896-9a0b3cdc50ec%2522%252c%2522Oid%2522%253a%2522e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%2522%257d \n\n
+URL:https://teams.microsoft.com/l/meetup-join/19%3ameeting_MDIzODI0M2YtZWQ5ZS00NjgyLWIwODMtYTljOWUzMTI1Yjlk%40thread.v2/0?context=%7b%22Tid%22%3a%22f99512c1-fd9f-4475-9896-9a0b3cdc50ec%22%2c%22Oid%22%3a%22e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%22%7d
+DESCRIPTION:The PRONOM team would also like to share details of their PRONOM drop-in sessions. These are open/unstructured sessions with members of the PRONOM Team to talk about your current research and ask/answer any questions you may have. \n\nhttps://teams.microsoft.com/l/meetup-join/19%3ameeting_MDIzODI0M2YtZWQ5ZS00NjgyLWIwODMtYTljOWUzMTI1Yjlk%40thread.v2/0?context=%7b%22Tid%22%3a%22f99512c1-fd9f-4475-9896-9a0b3cdc50ec%22%2c%22Oid%22%3a%22e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%22%7d \n\n
 LOCATION:Online
 END:VEVENT
 END:VCALENDAR

--- a/Resources/calendar/pronom-drop-in-gmt.ics
+++ b/Resources/calendar/pronom-drop-in-gmt.ics
@@ -29,8 +29,8 @@ DTSTART;TZID=Europe/Berlin:20230525T170000
 RRULE:FREQ=WEEKLY;INTERVAL=2;BYDAY=TH
 DTEND;TZID=Europe/Berlin:20230525T180000
 SUMMARY:PRONOM Drop-in Session (GMT, ET)
-URL:https://teams.microsoft.com/l/meetup-join/19%253ameeting_OThkMzIwMWItYTUzYS00NDIxLTgzNTEtMzAwMGQzYWZhNmJi%2540thread.v2/0?context=%257b%2522Tid%2522%253a%2522f99512c1-fd9f-4475-9896-9a0b3cdc50ec%2522%252c%2522Oid%2522%253a%2522e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%2522%257d
-DESCRIPTION:The PRONOM team would also like to share details of their PRONOM drop-in sessions. These are open/unstructured sessions with members of the PRONOM Team to talk about your current research and ask/answer any questions you may have. \n\nhttps://teams.microsoft.com/l/meetup-join/19%253ameeting_OThkMzIwMWItYTUzYS00NDIxLTgzNTEtMzAwMGQzYWZhNmJi%2540thread.v2/0?context=%257b%2522Tid%2522%253a%2522f99512c1-fd9f-4475-9896-9a0b3cdc50ec%2522%252c%2522Oid%2522%253a%2522e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%2522%257d \n\n
+URL:https://teams.microsoft.com/l/meetup-join/19%3ameeting_OThkMzIwMWItYTUzYS00NDIxLTgzNTEtMzAwMGQzYWZhNmJi%40thread.v2/0?context=%7b%22Tid%22%3a%22f99512c1-fd9f-4475-9896-9a0b3cdc50ec%22%2c%22Oid%22%3a%22e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%22%7d
+DESCRIPTION:The PRONOM team would also like to share details of their PRONOM drop-in sessions. These are open/unstructured sessions with members of the PRONOM Team to talk about your current research and ask/answer any questions you may have. \n\nhttps://teams.microsoft.com/l/meetup-join/19%3ameeting_OThkMzIwMWItYTUzYS00NDIxLTgzNTEtMzAwMGQzYWZhNmJi%40thread.v2/0?context=%7b%22Tid%22%3a%22f99512c1-fd9f-4475-9896-9a0b3cdc50ec%22%2c%22Oid%22%3a%22e02319b9-2b3a-4408-86ee-7cd0ba62ed9f%22%7d \n\n
 LOCATION:Online
 END:VEVENT
 END:VCALENDAR


### PR DESCRIPTION
As described in a [comment](https://github.com/digital-preservation/PRONOM_Research/pull/23#issuecomment-1625435266) on @ross-spencer's original PR, I couldn't join last week's meeting via the calendar entry imported from the new iCalendar files due to an issue with doubly percent-encoded URLs. This PR puts the same working URLs as used on the main Drop-in Markdown document there instead.

If the previous `.ics` file has already been added it needs to be re-imported after this change, should I add a note about this in _drop-in.md_ as well?