### PR TITLE
ISSUE templates aren't currently working: this will fix them by correcting the fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/new_file_format_submission.md
+++ b/.github/ISSUE_TEMPLATE/new_file_format_submission.md
@@ -1,6 +1,6 @@
 ---
 name: New File Format Submission
-description: This template is designed for anyone who would like to suggest a new file format for PRONOM
+about: This template is designed for anyone who would like to suggest a new file format for PRONOM
 title: ''
 labels: 'new-format'
 assignees: ''

--- a/.github/ISSUE_TEMPLATE/update_file_format_submission.md
+++ b/.github/ISSUE_TEMPLATE/update_file_format_submission.md
@@ -1,6 +1,6 @@
 ---
 name: Update File Format Submission
-description: This template is designed for anyone who would like to suggest improvements or changes to the current database
+about: This template is designed for anyone who would like to suggest improvements or changes to the current database
 title: ''
 labels: 'update-format'
 assignees: ''


### PR DESCRIPTION
Currently the ISSUES templates aren't working which makes it less intuitive to submit new formats. 

The issue seems to be caused by an errant `description` field (it makes sense as description but the field isn't valid).

![image](https://github.com/user-attachments/assets/b1476866-0a9b-454f-80a4-8553c87901f2)

I just swapped the keys around from description to about and this should allow the forms to work as they did previously. 

----

More info:

## Required

`name` (String): The template's name. Must be unique across all templates, including Markdown templates.
`about` (String): A description of this template's intended use. This will be shown in the issue template chooser interface.

## Optional

* `assignees` (Array or String): This issue will be automatically assigned to these users. Can be array of usernames or comma-delimited string, e.g. "monalisa,nat"
* `labels` (Array or String): This issue will automatically receive these labels upon creation. Can be array of labels or comma-delimited string, e.g. "bug,needs-triage"
* `title` (String): Default title that will be pre-populated in the issue submission form.
* `body` (Array): Definition of user inputs.